### PR TITLE
flow hook tracks flow state and resolution, replacing init promise

### DIFF
--- a/docs/docs/api/define-sequent-flow.mdx
+++ b/docs/docs/api/define-sequent-flow.mdx
@@ -70,7 +70,7 @@ function CheckoutPage() {
 
 ## Returned wrappers
 
-- `useSequentFlow()` narrows `init()` so typed flows require an initial context of `TContext`
+- `useSequentFlow()` narrows `init()` so typed flows require an initial context of `TContext`, while preserving `status` and typed `result`
 - `useSequentStep()` narrows `context` to `TContext` and `advance()` patches to `Partial<TContext>`
 - `useSequentContext()` narrows `context` to `TContext | undefined` and `resolve()` to `TResult`
 

--- a/docs/docs/api/types.mdx
+++ b/docs/docs/api/types.mdx
@@ -29,10 +29,22 @@ interface TypedUseFlowReturn<
   TContext extends object,
   TResult = unknown,
 > {
-  init: (stepLoader: StepLoader, initialContext: TContext) => Promise<TResult>;
+  init: (stepLoader: StepLoader, initialContext: TContext) => void;
+  status: "idle" | "active";
+  result: SequentResult<TResult> | null;
   SequentOutlet: FunctionComponent<SequentOutletProps>;
 }
 ```
+
+## `SequentResult`
+
+```typescript
+type SequentResult<TResult = unknown> =
+  | { status: "resolved"; value: TResult }
+  | { status: "aborted"; reason: unknown };
+```
+
+Latest terminal outcome exposed by `useSequentFlow().result`.
 
 ## `TypedUseStepReturn`
 

--- a/docs/docs/api/use-sequent-flow.mdx
+++ b/docs/docs/api/use-sequent-flow.mdx
@@ -16,7 +16,9 @@ It returns:
 
 ```typescript
 function useSequentFlow<TResult = unknown>(): {
-  init: (stepLoader: StepLoader, initialContext?: unknown) => Promise<TResult>;
+  init: (stepLoader: StepLoader, initialContext?: unknown) => void;
+  status: "idle" | "active";
+  result: SequentResult<TResult> | null;
   SequentOutlet: (props: SequentOutletProps) => ReactElement;
 };
 ```
@@ -37,12 +39,17 @@ function Step2() {
 }
 
 function App() {
-  const { init, SequentOutlet } = useSequentFlow<string>();
+  const { init, status, result, SequentOutlet } = useSequentFlow<string>();
 
-  const start = async () => {
-    const result = await init(() => Step1);
-    console.log(result);
+  const start = () => {
+    init(() => Step1);
   };
+
+  React.useEffect(() => {
+    if (status === "idle" && result?.status === "resolved") {
+      console.log(result.value);
+    }
+  }, [status, result]);
 
   return (
     <>
@@ -57,6 +64,8 @@ function App() {
 
 - One `useSequentFlow()` call creates one isolated flow host.
 - `SequentOutlet` stays idle until `init()` is called.
+- `status` reports whether a flow is currently active.
+- `result` stores the latest terminal outcome (`resolved` or `aborted`).
 - `children`, `fallback`, `errorFallback`, and `chrome` are still configured on `SequentOutlet`.
 - `init()` accepts any `StepLoader`, including factories that return JSX elements.
 - `init()` throws if `SequentOutlet` is not currently mounted.

--- a/docs/docs/demos/subsection-flow.mdx
+++ b/docs/docs/demos/subsection-flow.mdx
@@ -11,8 +11,8 @@ Click **Begin Checkout** below to start the flow directly on this page.
 
 ```jsx live
 function CheckoutSection() {
-  const { init, SequentOutlet } = useSequentFlow();
-  const [status, setStatus] = React.useState(null);
+  const { init, status: flowStatus, result, SequentOutlet } = useSequentFlow();
+  const [message, setMessage] = React.useState(null);
 
   function StepAddress() {
     const { advance } = useSequentStep();
@@ -84,11 +84,16 @@ function CheckoutSection() {
     );
   }
 
-  async function start() {
-    setStatus(null);
-    const result = await init(() => StepAddress);
-    setStatus(`Order placed! ${JSON.stringify(result)}`);
+  function start() {
+    setMessage(null);
+    init(() => StepAddress);
   }
+
+  React.useEffect(() => {
+    if (flowStatus === "idle" && result?.status === "resolved") {
+      setMessage(`Order placed! ${JSON.stringify(result.value)}`);
+    }
+  }, [flowStatus, result]);
 
   return (
     <div className="demo-checkout">
@@ -98,7 +103,7 @@ function CheckoutSection() {
       <SequentOutlet>
         <IdleContent />
       </SequentOutlet>
-      {status && <div className="demo-checkout__status">{status}</div>}
+      {message && <div className="demo-checkout__status">{message}</div>}
     </div>
   );
 }
@@ -110,7 +115,7 @@ function CheckoutSection() {
 2. `IdleContent` calls `useSequentContext()` to check if a previous flow completed — if so, the button reads "Begin Checkout Again".
 3. Clicking the button calls `init(() => StepAddress)`, which replaces the idle children with `StepAddress` inside the outlet.
 4. Each step calls `advance(NextStep)` to move forward or `retreat()` to go back.
-5. `StepReview` calls `resolve(value)` — the `await init(...)` promise resolves with that value, the outlet returns to idle, and the `IdleContent` reappears with the updated button label.
+5. `StepReview` calls `resolve(value)` — `useSequentFlow().result` captures the resolved value, the outlet returns to idle, and the `IdleContent` reappears with the updated button label.
 
 ## Key points
 

--- a/docs/docs/demos/subsection-flow.mdx
+++ b/docs/docs/demos/subsection-flow.mdx
@@ -12,7 +12,13 @@ Click **Begin Checkout** below to start the flow directly on this page.
 ```jsx live
 function CheckoutSection() {
   const { init, status: flowStatus, result, SequentOutlet } = useSequentFlow();
-  const [message, setMessage] = React.useState(null);
+  const message = React.useMemo(() => {
+    if (flowStatus === "idle" && result?.status === "resolved") {
+      return `Order placed! ${JSON.stringify(result.value)}`;
+    }
+
+    return null;
+  }, [flowStatus, result]);
 
   function StepAddress() {
     const { advance } = useSequentStep();
@@ -85,15 +91,8 @@ function CheckoutSection() {
   }
 
   function start() {
-    setMessage(null);
     init(() => StepAddress);
   }
-
-  React.useEffect(() => {
-    if (flowStatus === "idle" && result?.status === "resolved") {
-      setMessage(`Order placed! ${JSON.stringify(result.value)}`);
-    }
-  }, [flowStatus, result]);
 
   return (
     <div className="demo-checkout">

--- a/docs/docs/demos/toast.mdx
+++ b/docs/docs/demos/toast.mdx
@@ -69,22 +69,21 @@ function ToastDemo() {
 
   function SaveButton() {
     const { toast, status, result } = useToast();
-    const [log, setLog] = React.useState("");
+    const log = React.useMemo(() => {
+      if (status === "active") {
+        return "Toast active…";
+      }
+
+      if (status === "idle" && result?.status === "resolved") {
+        return "Toast dismissed.";
+      }
+
+      return "";
+    }, [status, result]);
 
     function handleClick() {
       toast("Changes saved successfully!");
     }
-
-    React.useEffect(() => {
-      if (status === "active") {
-        setLog("Toast active…");
-        return;
-      }
-
-      if (status === "idle" && result?.status === "resolved") {
-        setLog("Toast dismissed.");
-      }
-    }, [status, result]);
 
     return (
       <div className="demo-sandbox">

--- a/docs/docs/demos/toast.mdx
+++ b/docs/docs/demos/toast.mdx
@@ -47,14 +47,14 @@ function ToastDemo() {
   }
 
   function ToastProvider({ children }) {
-    const { init, SequentOutlet } = useSequentFlow();
+    const { init, status, result, SequentOutlet } = useSequentFlow();
 
-    async function toast(message) {
-      return init(() => ToastStep, { message });
+    function toast(message) {
+      init(() => ToastStep, { message });
     }
 
     return (
-      <ToastContext.Provider value={{ toast }}>
+      <ToastContext.Provider value={{ toast, status, result }}>
         {children}
         <SequentOutlet
           chrome={(slot) => <div className="demo-toast__chrome">{slot}</div>}
@@ -68,14 +68,23 @@ function ToastDemo() {
   // ── Consumer ──────────────────────────────────────────────────────────────
 
   function SaveButton() {
-    const { toast } = useToast();
+    const { toast, status, result } = useToast();
     const [log, setLog] = React.useState("");
 
-    async function handleClick() {
-      setLog("Toast active…");
-      await toast("Changes saved successfully!");
-      setLog("Toast dismissed.");
+    function handleClick() {
+      toast("Changes saved successfully!");
     }
+
+    React.useEffect(() => {
+      if (status === "active") {
+        setLog("Toast active…");
+        return;
+      }
+
+      if (status === "idle" && result?.status === "resolved") {
+        setLog("Toast dismissed.");
+      }
+    }, [status, result]);
 
     return (
       <div className="demo-sandbox">
@@ -144,11 +153,11 @@ The chrome positions the outlet in the corner without knowing anything about tim
 />
 ```
 
-The `toast()` helper seeds context with the message and returns the same promise as `init`, so callers can `await` it if they need to act after the toast disappears.
+The `toast()` helper seeds context with the message and starts the flow. Consumers can react to dismissal by observing `status` and `result` from `useSequentFlow()`.
 
 ## Key points
 
 - **Self-terminating step** — `resolve` called from `useEffect` after a delay ends the flow without any external timer or state.
 - **Chrome is the container** — positioning and z-index live in the chrome, keeping the step itself presentational.
-- **Awaitable** — because `init()` returns a promise, callers can optionally `await toast(...)` to react after dismissal.
+- **Reactive completion** — callers can react after dismissal by checking `status === "idle"` and `result?.status === "resolved"`.
 - **Not a replacement for a toast library** — dedicated libraries offer queuing, stacking, and animation out of the box. Use this approach when you specifically want to avoid adding a dependency.

--- a/docs/docs/getting-started.mdx
+++ b/docs/docs/getting-started.mdx
@@ -53,12 +53,17 @@ function Step2() {
 
 // Host — owns the outlet and starts the flow
 function App() {
-  const { init, SequentOutlet } = useSequentFlow();
+  const { init, status, result, SequentOutlet } = useSequentFlow();
 
-  const start = async () => {
-    const result = await init(() => Step1);
-    console.log("Flow resolved:", result);
+  const start = () => {
+    init(() => Step1);
   };
+
+  React.useEffect(() => {
+    if (status === "idle" && result?.status === "resolved") {
+      console.log("Flow resolved:", result.value);
+    }
+  }, [status, result]);
 
   return (
     <div>
@@ -74,7 +79,7 @@ function App() {
 1. **`useSequentFlow`** gives you `init` and a bound **`SequentOutlet`**.
 2. **`<SequentOutlet>`** is where the flow renders. It's idle until `init()` activates it.
 3. **`useSequentStep`** is called inside step components. It returns `advance`, `retreat`, `resolve`, and `abort`.
-4. When `resolve("completed!")` is called, the promise returned by `init()` resolves with that value.
+4. When `resolve("completed!")` is called, `useSequentFlow().result` becomes `{ status: "resolved", value: "completed!" }`.
 
 ## Key Concepts
 

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -52,12 +52,14 @@ Primary hook for creating and controlling a single flow host.
 
 ```typescript
 function useSequentFlow<TResult = unknown>(): {
-  init: (stepLoader: StepLoader, initialContext?: unknown) => Promise<TResult>;
+  init: (stepLoader: StepLoader, initialContext?: unknown) => void;
+  status: "idle" | "active";
+  result: SequentResult<TResult> | null;
   SequentOutlet: FunctionComponent<SequentOutletProps>;
 };
 ```
 
-- `init(stepLoader, initialContext?)` — starts a flow. Returns a promise that resolves when the step calls `resolve(value)` or rejects when a step calls `abort(reason)`. Throws if `SequentOutlet` is not currently mounted.
+- `init(stepLoader, initialContext?)` — starts a flow. Sets `status` to `active`, then returns `void`. When the step calls `resolve(value)` or `abort(reason)`, `result` is updated and `status` returns to `idle`. Throws if `SequentOutlet` is not currently mounted.
 - `SequentOutlet` — a bound outlet component for this hook instance. Renders idle children when no flow is active. Accepts `children`, `fallback`, `errorFallback`, and `chrome` props.
 
 One `useSequentFlow()` call creates one isolated flow host. Multiple hosts can coexist via separate `useSequentFlow()` calls.
@@ -78,8 +80,8 @@ function useSequentStep<TResult = unknown>(): {
 
 - `advance(nextStep, contextPatch?)` — pushes the current step to history and renders `nextStep`. If `contextPatch` is provided and both the current context and patch are objects, they are shallow-merged; otherwise the patch replaces the context.
 - `retreat()` — pops the history stack and renders the previous step. Always synchronous. No-ops if history is empty.
-- `resolve(value?)` — ends the flow successfully. The promise from `init()` resolves with `value`.
-- `abort(reason?)` — ends the flow without completing. The promise from `init()` rejects with `reason`.
+- `resolve(value?)` — ends the flow successfully. `useSequentFlow().result` becomes `{ status: "resolved", value }`.
+- `abort(reason?)` — ends the flow without completing. `useSequentFlow().result` becomes `{ status: "aborted", reason }`.
 - `context` — the current flow context value (typed as `unknown` unless using `defineSequentFlow`).
 
 ### `useSequentContext<TContext>()`
@@ -153,7 +155,9 @@ interface SequentFlowDefinition<TContext extends object, TResult = unknown> {
 }
 
 interface TypedUseFlowReturn<TContext extends object, TResult = unknown> {
-  init: (stepLoader: StepLoader, initialContext: TContext) => Promise<TResult>;
+  init: (stepLoader: StepLoader, initialContext: TContext) => void;
+  status: "idle" | "active";
+  result: SequentResult<TResult> | null;
   SequentOutlet: FunctionComponent<SequentOutletProps>;
 }
 
@@ -250,11 +254,15 @@ function Step2() {
 }
 
 function App() {
-  const { init, SequentOutlet } = useSequentFlow();
-  const start = async () => {
-    const result = await init(() => Step1);
-    console.log("Flow resolved:", result);
+  const { init, status, result, SequentOutlet } = useSequentFlow();
+  const start = () => {
+    init(() => Step1);
   };
+  React.useEffect(() => {
+    if (status === "idle" && result?.status === "resolved") {
+      console.log("Flow resolved:", result.value);
+    }
+  }, [status, result]);
   return (
     <>
       <SequentOutlet />

--- a/src/components/FlowOutlet.tsx
+++ b/src/components/FlowOutlet.tsx
@@ -43,6 +43,7 @@ export interface FlowOutletHandle {
     initialContext?: unknown,
     onResolve?: (value?: unknown) => void,
     onAbort?: (reason?: unknown) => void,
+    onActivated?: () => void,
   ) => void;
 }
 // #endregion doc:handle
@@ -51,6 +52,13 @@ interface FlowState {
   history: ComponentType[];
   activeStep: ComponentType;
   consumerContext: unknown;
+}
+
+function reportLoaderError(phase: "activate" | "advance", error: unknown) {
+  console.error(
+    `FlowOutlet.${phase}() failed while normalizing a step loader. The flow was left idle.`,
+    error,
+  );
 }
 
 // #region doc:props
@@ -94,7 +102,13 @@ export const FlowOutlet = forwardRef<FlowOutletHandle, FlowOutletProps>(
     const advance = useCallback(
       (nextStep: StepLoader, contextPatch?: unknown) => {
         if (flowIdRef.current !== activeFlowId) return;
-        const nextActiveStep = normalizeStepLoader(nextStep);
+        let nextActiveStep: ComponentType;
+        try {
+          nextActiveStep = normalizeStepLoader(nextStep);
+        } catch (error) {
+          reportLoaderError("advance", error);
+          throw error;
+        }
         if (flowIdRef.current !== activeFlowId) return;
         errorBoundaryRef.current?.resetError();
         setFlowState((prev) => {
@@ -142,9 +156,16 @@ export const FlowOutlet = forwardRef<FlowOutletHandle, FlowOutletProps>(
           initialContext?: unknown,
           onResolve?: (value?: unknown) => void,
           onAbort?: (reason?: unknown) => void,
+          onActivated?: () => void,
         ) {
           const activeFlowId = flowIdRef.current;
-          const activeStep = normalizeStepLoader(stepLoader);
+          let activeStep: ComponentType;
+          try {
+            activeStep = normalizeStepLoader(stepLoader);
+          } catch (error) {
+            reportLoaderError("activate", error);
+            throw error;
+          }
           if (flowIdRef.current !== activeFlowId) return;
           errorBoundaryRef.current?.resetError();
           flowIdRef.current += 1;
@@ -155,6 +176,7 @@ export const FlowOutlet = forwardRef<FlowOutletHandle, FlowOutletProps>(
             activeStep,
             consumerContext: initialContext,
           });
+          onActivated?.();
         },
       }),
       [],

--- a/src/defineSequentFlow.ts
+++ b/src/defineSequentFlow.ts
@@ -1,6 +1,10 @@
 import { type FunctionComponent, useCallback } from "react";
 import { type SequentContextReturn, useSequentContext } from "./hooks/useSequentContext";
-import { type SequentOutletProps, useSequentFlow } from "./hooks/useSequentFlow";
+import {
+  type SequentOutletProps,
+  type SequentResult,
+  useSequentFlow,
+} from "./hooks/useSequentFlow";
 import { useSequentStep } from "./hooks/useSequentStep";
 import type { StepLoader } from "./internal/normalizer";
 
@@ -11,7 +15,9 @@ type InvalidTypedContextArgs<TContext extends object> = TContext extends readonl
     : [];
 
 export interface TypedUseFlowReturn<TContext extends object, TResult = unknown> {
-  init: (stepLoader: StepLoader, initialContext: TContext) => Promise<TResult>;
+  init: (stepLoader: StepLoader, initialContext: TContext) => void;
+  status: "idle" | "active";
+  result: SequentResult<TResult> | null;
   SequentOutlet: FunctionComponent<SequentOutletProps>;
 }
 
@@ -41,7 +47,7 @@ export function defineSequentFlow<
 >(..._invalidContext: InvalidTypedContextArgs<TContext>): SequentFlowDefinition<TContext, TResult> {
   return {
     useSequentFlow(): TypedUseFlowReturn<TContext, TResult> {
-      const { init, SequentOutlet } = useSequentFlow<TResult>();
+      const { init, status, result, SequentOutlet } = useSequentFlow<TResult>();
 
       const typedInit = useCallback(
         (stepLoader: StepLoader, initialContext: TContext) => init(stepLoader, initialContext),
@@ -50,6 +56,8 @@ export function defineSequentFlow<
 
       return {
         init: typedInit,
+        status,
+        result,
         SequentOutlet,
       };
     },

--- a/src/defineSequentFlow.typecheck.ts
+++ b/src/defineSequentFlow.typecheck.ts
@@ -20,9 +20,22 @@ declare const flowApi: ReturnType<typeof useSequentFlow>;
 declare const stepApi: ReturnType<typeof useSequentStep>;
 declare const contextApi: ReturnType<typeof useSequentContext>;
 
-const flowPromise: Promise<CheckoutResult> = flowApi.init(() => StepComponent, {
+const initResult: undefined = flowApi.init(() => StepComponent, {
   cartId: "cart-1",
 });
+const flowStatus: "idle" | "active" = flowApi.status;
+const flowResult = flowApi.result;
+
+if (flowResult?.status === "resolved") {
+  const resolvedOrderId: string = flowResult.value.orderId;
+  void resolvedOrderId;
+}
+
+if (flowResult?.status === "aborted") {
+  const abortReason: unknown = flowResult.reason;
+  void abortReason;
+}
+
 const activeContext: CheckoutContext = stepApi.context;
 const maybeIdleContext: CheckoutContext | undefined = contextApi.context;
 
@@ -30,7 +43,9 @@ stepApi.advance(() => StepComponent, { shippingAddress: "123 Main" });
 stepApi.resolve({ orderId: "order-1" });
 contextApi.resolve({ orderId: "order-2" });
 
-void flowPromise;
+void initResult;
+void flowStatus;
+void flowResult;
 void activeContext;
 void maybeIdleContext;
 

--- a/src/defineSequentFlow.typecheck.ts
+++ b/src/defineSequentFlow.typecheck.ts
@@ -20,7 +20,7 @@ declare const flowApi: ReturnType<typeof useSequentFlow>;
 declare const stepApi: ReturnType<typeof useSequentStep>;
 declare const contextApi: ReturnType<typeof useSequentContext>;
 
-const initResult: undefined = flowApi.init(() => StepComponent, {
+flowApi.init(() => StepComponent, {
   cartId: "cart-1",
 });
 const flowStatus: "idle" | "active" = flowApi.status;
@@ -43,7 +43,6 @@ stepApi.advance(() => StepComponent, { shippingAddress: "123 Main" });
 stepApi.resolve({ orderId: "order-1" });
 contextApi.resolve({ orderId: "order-2" });
 
-void initResult;
 void flowStatus;
 void flowResult;
 void activeContext;

--- a/src/hooks/__tests__/defineSequentFlow.test.tsx
+++ b/src/hooks/__tests__/defineSequentFlow.test.tsx
@@ -60,13 +60,23 @@ function TypedHost({
   children?: ReactNode;
   onInit?: (init: InitFn) => void;
 }) {
-  const { init, SequentOutlet } = useSequentFlow();
+  const { init, status, result, SequentOutlet } = useSequentFlow();
+
+  const resultLabel =
+    result === null
+      ? "none"
+      : result.status === "resolved"
+        ? `resolved:${result.value.orderId}`
+        : "aborted";
 
   return (
     <>
       <button type="button" onClick={() => onInit?.(init)}>
         Init
       </button>
+      <div>
+        flow:{status}:{resultLabel}
+      </div>
       <SequentOutlet
         chrome={(step) => (
           <>
@@ -141,12 +151,10 @@ describe("defineSequentFlow", () => {
   });
 
   it("resolves with the typed TResult and preserves last resolved idle context", async () => {
-    let promise: Promise<CheckoutResult> | undefined;
-
     render(
       <TypedHost
         onInit={(init) => {
-          promise = init(() => ShippingStep, { cartId: "cart-3", shippingAddress: "saved" });
+          init(() => ShippingStep, { cartId: "cart-3", shippingAddress: "saved" });
         }}
       >
         <IdleReader />
@@ -167,7 +175,7 @@ describe("defineSequentFlow", () => {
       screen.getByText("Finish:cart-3-ship").click();
     });
 
-    await expect(promise).resolves.toEqual({ orderId: "cart-3" });
+    expect(screen.getByText("flow:idle:resolved:cart-3")).toBeInTheDocument();
     expect(screen.getByText("idle:cart-3-ship")).toBeInTheDocument();
   });
 });

--- a/src/hooks/__tests__/useSequentFlow.test.tsx
+++ b/src/hooks/__tests__/useSequentFlow.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 import type { ReactNode } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useSequentContext } from "../useSequentContext";
 import { useSequentFlow } from "../useSequentFlow";
 import { useSequentStep } from "../useSequentStep";
@@ -517,6 +517,53 @@ describe("useSequentFlow", () => {
       }).toThrowError(
         "SequentOutlet is not mounted. Ensure <SequentOutlet /> is rendered before calling init().",
       );
+    });
+
+    it("keeps status idle when the initial step loader throws during activation", () => {
+      const loaderError = new Error("loader failed");
+      let capturedInit!: InitFn;
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      function CaptureFlowState() {
+        const { init, status, result, SequentOutlet } = useSequentFlow();
+        capturedInit = init;
+
+        const resultLabel =
+          result === null
+            ? "none"
+            : result.status === "resolved"
+              ? `resolved:${JSON.stringify(result.value)}`
+              : `aborted:${JSON.stringify(result.reason)}`;
+
+        return (
+          <>
+            <div>status:{status}</div>
+            <div>result:{resultLabel}</div>
+            <SequentOutlet />
+          </>
+        );
+      }
+
+      render(<CaptureFlowState />);
+
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+      expect(screen.getByText("result:none")).toBeInTheDocument();
+
+      expect(() => {
+        capturedInit(() => {
+          throw loaderError;
+        });
+      }).toThrow(loaderError);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("FlowOutlet.activate() failed while normalizing a step loader"),
+        loaderError,
+      );
+
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+      expect(screen.getByText("result:none")).toBeInTheDocument();
+
+      consoleErrorSpy.mockRestore();
     });
   });
 

--- a/src/hooks/__tests__/useSequentFlow.test.tsx
+++ b/src/hooks/__tests__/useSequentFlow.test.tsx
@@ -135,26 +135,28 @@ function TestHost({ children, onInit }: { children?: ReactNode; onInit?: (init: 
   );
 }
 
-function TestHostWithPromise({
-  onPromise,
-  step,
-}: {
-  onPromise?: (promise: Promise<unknown>) => void;
-  step: Parameters<InitFn>[0];
-}) {
-  const { init, SequentOutlet } = useSequentFlow();
+function TestHostWithFlowState({ step }: { step: Parameters<InitFn>[0] }) {
+  const { init, status, result, SequentOutlet } = useSequentFlow();
+
+  const resultLabel =
+    result === null
+      ? "none"
+      : result.status === "resolved"
+        ? `resolved:${JSON.stringify(result.value)}`
+        : `aborted:${JSON.stringify(result.reason)}`;
 
   return (
     <>
       <button
         type="button"
         onClick={() => {
-          const promise = init(step);
-          onPromise?.(promise);
+          init(step);
         }}
       >
         Init
       </button>
+      <div>status:{status}</div>
+      <div>result:{resultLabel}</div>
       <SequentOutlet />
     </>
   );
@@ -245,27 +247,25 @@ describe("useSequentFlow", () => {
       expect(screen.queryByText("Resolve")).not.toBeInTheDocument();
     });
 
-    it("resolves the init promise with the value passed to resolve()", async () => {
-      let promise: Promise<unknown> | undefined;
+    it("stores resolved result state with the value passed to resolve()", async () => {
+      render(<TestHostWithFlowState step={() => StepWithResolveValue} />);
 
-      render(
-        <TestHostWithPromise
-          onPromise={(nextPromise) => {
-            promise = nextPromise;
-          }}
-          step={() => StepWithResolveValue}
-        />,
-      );
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+      expect(screen.getByText("result:none")).toBeInTheDocument();
 
       await act(async () => {
         screen.getByText("Init").click();
       });
 
+      expect(screen.getByText("status:active")).toBeInTheDocument();
+      expect(screen.getByText("result:none")).toBeInTheDocument();
+
       await act(async () => {
         screen.getByText("ResolveValue").click();
       });
 
-      await expect(promise).resolves.toBe("success-value");
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+      expect(screen.getByText('result:resolved:"success-value"')).toBeInTheDocument();
     });
   });
 
@@ -291,27 +291,25 @@ describe("useSequentFlow", () => {
       expect(screen.queryByText("Abort")).not.toBeInTheDocument();
     });
 
-    it("rejects the init promise with the reason passed to abort()", async () => {
-      let promise: Promise<unknown> | undefined;
+    it("stores aborted result state with the reason passed to abort()", async () => {
+      render(<TestHostWithFlowState step={() => StepWithAbortReason} />);
 
-      render(
-        <TestHostWithPromise
-          onPromise={(nextPromise) => {
-            promise = nextPromise;
-          }}
-          step={() => StepWithAbortReason}
-        />,
-      );
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+      expect(screen.getByText("result:none")).toBeInTheDocument();
 
       await act(async () => {
         screen.getByText("Init").click();
       });
 
+      expect(screen.getByText("status:active")).toBeInTheDocument();
+      expect(screen.getByText("result:none")).toBeInTheDocument();
+
       await act(async () => {
         screen.getByText("AbortReason").click();
       });
 
-      await expect(promise).rejects.toBe("abort-reason");
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+      expect(screen.getByText('result:aborted:"abort-reason"')).toBeInTheDocument();
     });
   });
 
@@ -546,6 +544,28 @@ describe("useSequentFlow", () => {
         screen.getByText("Init").click();
       });
       expect(screen.getByText("Resolve")).toBeInTheDocument();
+    });
+
+    it("keeps the last result while a new flow is active", async () => {
+      render(<TestHostWithFlowState step={() => StepWithResolveValue} />);
+
+      await act(async () => {
+        screen.getByText("Init").click();
+      });
+
+      await act(async () => {
+        screen.getByText("ResolveValue").click();
+      });
+
+      expect(screen.getByText('result:resolved:"success-value"')).toBeInTheDocument();
+      expect(screen.getByText("status:idle")).toBeInTheDocument();
+
+      await act(async () => {
+        screen.getByText("Init").click();
+      });
+
+      expect(screen.getByText('result:resolved:"success-value"')).toBeInTheDocument();
+      expect(screen.getByText("status:active")).toBeInTheDocument();
     });
   });
 

--- a/src/hooks/useSequentFlow.tsx
+++ b/src/hooks/useSequentFlow.tsx
@@ -4,21 +4,30 @@ import {
   useCallback,
   useMemo,
   useRef,
+  useState,
 } from "react";
 import { FlowOutlet, type FlowOutletHandle } from "../components/FlowOutlet";
 import type { StepLoader } from "../internal/normalizer";
 
 export type SequentOutletProps = ComponentPropsWithoutRef<typeof FlowOutlet>;
 
+export type SequentResult<TResult = unknown> =
+  | { status: "resolved"; value: TResult }
+  | { status: "aborted"; reason: unknown };
+
 export interface UseSequentFlowReturn<TResult = unknown> {
-  init: (stepLoader: StepLoader, initialContext?: unknown) => Promise<TResult>;
+  init: (stepLoader: StepLoader, initialContext?: unknown) => void;
+  status: "idle" | "active";
+  result: SequentResult<TResult> | null;
   SequentOutlet: FunctionComponent<SequentOutletProps>;
 }
 
 export function useSequentFlow<TResult = unknown>(): UseSequentFlowReturn<TResult> {
   const outletRef = useRef<FlowOutletHandle>(null);
+  const [status, setStatus] = useState<"idle" | "active">("idle");
+  const [result, setResult] = useState<SequentResult<TResult> | null>(null);
 
-  const init = useCallback((stepLoader: StepLoader, initialContext?: unknown): Promise<TResult> => {
+  const init = useCallback((stepLoader: StepLoader, initialContext?: unknown): void => {
     const outlet = outletRef.current;
     // TODO instead of throwing, we could queue the init call and execute it once the outlet mounts.
     // This would allow init() to be called before the outlet is rendered.
@@ -29,17 +38,19 @@ export function useSequentFlow<TResult = unknown>(): UseSequentFlowReturn<TResul
       );
     }
 
-    const promise = new Promise<TResult>((resolve, reject) => {
-      outlet.activate(
-        stepLoader,
-        initialContext,
-        (value) => resolve(value as TResult),
-        (reason) => reject(reason),
-      );
-    });
-
-    promise.catch(() => {});
-    return promise;
+    setStatus("active");
+    outlet.activate(
+      stepLoader,
+      initialContext,
+      (value) => {
+        setResult({ status: "resolved", value: value as TResult });
+        setStatus("idle");
+      },
+      (reason) => {
+        setResult({ status: "aborted", reason });
+        setStatus("idle");
+      },
+    );
   }, []);
 
   const SequentOutlet = useMemo<FunctionComponent<SequentOutletProps>>(() => {
@@ -53,6 +64,8 @@ export function useSequentFlow<TResult = unknown>(): UseSequentFlowReturn<TResul
 
   return {
     init,
+    status,
+    result,
     SequentOutlet,
   };
 }

--- a/src/hooks/useSequentFlow.tsx
+++ b/src/hooks/useSequentFlow.tsx
@@ -38,7 +38,6 @@ export function useSequentFlow<TResult = unknown>(): UseSequentFlowReturn<TResul
       );
     }
 
-    setStatus("active");
     outlet.activate(
       stepLoader,
       initialContext,
@@ -49,6 +48,9 @@ export function useSequentFlow<TResult = unknown>(): UseSequentFlowReturn<TResul
       (reason) => {
         setResult({ status: "aborted", reason });
         setStatus("idle");
+      },
+      () => {
+        setStatus("active");
       },
     );
   }, []);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export type { SequentContextReturn } from "./hooks/useSequentContext";
 export { useSequentContext } from "./hooks/useSequentContext";
 export type {
   SequentOutletProps,
+  SequentResult,
   UseSequentFlowReturn,
 } from "./hooks/useSequentFlow";
 export { useSequentFlow } from "./hooks/useSequentFlow";

--- a/src/stories/ErrorBoundary.stories.tsx
+++ b/src/stories/ErrorBoundary.stories.tsx
@@ -1,5 +1,4 @@
 import { Alert, Button, Group, Paper, Stack, Text, Title } from "@mantine/core";
-import { useSequentContext } from "../hooks/useSequentContext";
 import { useSequentFlow } from "../hooks/useSequentFlow";
 import { useSequentStep } from "../hooks/useSequentStep";
 
@@ -30,13 +29,11 @@ function BrokenStep(): never {
 function TerminalStep(): React.ReactElement {
   const { context, resolve } = useSequentStep<{ recovered?: boolean }>();
   const recoveredContext = context as Record<string, unknown> | null;
-  const wasRecovered = recoveredContext?.["recovered"] === true;
+  const wasRecovered = recoveredContext?.recovered === true;
 
   return (
     <Stack>
-      {wasRecovered ? (
-        <Alert color="green" title="Flow recovered successfully"/>
-      ) : null}
+      {wasRecovered ? <Alert color="green" title="Flow recovered successfully" /> : null}
       <Title order={4}>Terminal</Title>
       <Text c="dimmed">The flow reached the terminal step successfully.</Text>
       <Group justify="flex-end">
@@ -68,7 +65,12 @@ function ErrorFallback() {
         >
           Recover
         </Button>
-        <Button size="xs" variant="light" color="red" onClick={() => abort("aborted-from-fallback")}>
+        <Button
+          size="xs"
+          variant="light"
+          color="red"
+          onClick={() => abort("aborted-from-fallback")}
+        >
           Abort!
         </Button>
       </Group>
@@ -76,12 +78,16 @@ function ErrorFallback() {
   );
 }
 
-function IdleContent({ init }: { init: ReturnType<typeof useSequentFlow>["init"] }) {
-  const { status } = useSequentContext();
-
+function IdleContent({
+  init,
+  result,
+}: {
+  init: ReturnType<typeof useSequentFlow>["init"];
+  result: ReturnType<typeof useSequentFlow>["result"];
+}) {
   return (
     <Stack>
-      {status === "aborted" ? (
+      {result?.status === "aborted" ? (
         <Alert color="yellow" title="Flow aborted">
           The flow was aborted and returned to the idle state.
         </Alert>
@@ -97,11 +103,11 @@ function IdleContent({ init }: { init: ReturnType<typeof useSequentFlow>["init"]
 }
 
 function Host() {
-  const { init, SequentOutlet } = useSequentFlow();
+  const { init, result, SequentOutlet } = useSequentFlow();
   return (
     <Paper withBorder p="xl" maw={400} mx="auto" mt="xl" radius="md">
       <SequentOutlet errorFallback={<ErrorFallback />}>
-        <IdleContent init={init} />
+        <IdleContent init={init} result={result} />
       </SequentOutlet>
     </Paper>
   );


### PR DESCRIPTION
- [x] Fix `defineSequentFlow.typecheck.ts` to call `flowApi.init()` without assigning the return value, satisfying both TypeScript's `void` return type and biome's `noConfusingVoidType` rule